### PR TITLE
Revert the blue sidebar back to original color in pdf viewer

### DIFF
--- a/userContent-files/pdf.css
+++ b/userContent-files/pdf.css
@@ -39,14 +39,6 @@
     background-color: var(--theme-selection-background-hover)!important;
     border-bottom: 1px solid!important
   }
-  #sidebarContainer {
-    background-color: var(--in-content-table-header-background)!important
-  }
-  #toolbarSidebar {
-    background-color: var(--in-content-table-header-background)!important;
-    background-image: none!important;
-    border-color: var(--in-content-box-background)!important
-  }
   .doorHanger,
   .doorHangerRight {
     border: 1px solid!important;


### PR DESCRIPTION
The blue sidebar is really out of place when viewing a pdf.
I reverted it back to its original state.
![s1](https://user-images.githubusercontent.com/10200748/37175744-be8fd352-231a-11e8-8847-75c04744b7f8.png)
vs
![s2](https://user-images.githubusercontent.com/10200748/37175745-beb060d6-231a-11e8-9b89-e43164a19734.png)
