### PR TITLE
More thorough regex for uuid finder

### DIFF
--- a/internal_UUID_finder.sh
+++ b/internal_UUID_finder.sh
@@ -25,7 +25,7 @@ declare -A styled=( ["brief@mozdev.org"]="brief"
                     ["vim-vixen@i-beam.org"]="vim_vixen"
                   )
 
-line=$(sed -n -e '/^user_pref("extensions.webextensions.uuids"/p' ../prefs.js)
+line=$(sed -n -e 's/^user_pref("extensions.webextensions.uuids", "{\(.*\).*}");/\1/p' "$profile/prefs.js")
 
 ## Remove prefix and suffix
 prefix='user_pref("extensions.webextensions.uuids", "{'
@@ -37,12 +37,8 @@ suffix='\\"'
 
 IFS=',' read -ra EXTS <<< "$line"
 for i in "${EXTS[@]}"; do
-    id=${i%:*}
-    uuid=${i#*:}
-    id=${id#$prefix}
-    id=${id%$suffix}
-    uuid=${uuid#$prefix}
-    uuid=${uuid%$suffix}
+    id=$(echo $i | sed -n 's/.*"\(.*\)\\":.*/\1/p')
+    uuid=$(echo $i | sed -n 's/.*"\(.*\)\\".*/\1/p')
     if test "${styled[$id]+isset}"
     then
         echo "${styled[$id]}_UUID=$uuid" >> 'ShadowFox_customization/internal_UUIDs.txt'

--- a/internal_UUID_finder.sh
+++ b/internal_UUID_finder.sh
@@ -27,14 +27,6 @@ declare -A styled=( ["brief@mozdev.org"]="brief"
 
 line=$(sed -n -e 's/^user_pref("extensions.webextensions.uuids", "{\(.*\).*}");/\1/p' ../prefs.js)
 
-## Remove prefix and suffix
-prefix='user_pref("extensions.webextensions.uuids", "{'
-suffix='}");'
-line=${line#$prefix}
-line=${line%$suffix}
-prefix='\\"'
-suffix='\\"'
-
 IFS=',' read -ra EXTS <<< "$line"
 for i in "${EXTS[@]}"; do
     id=$(echo $i | sed -n 's/.*"\(.*\)\\":.*/\1/p')

--- a/internal_UUID_finder.sh
+++ b/internal_UUID_finder.sh
@@ -25,7 +25,7 @@ declare -A styled=( ["brief@mozdev.org"]="brief"
                     ["vim-vixen@i-beam.org"]="vim_vixen"
                   )
 
-line=$(sed -n -e 's/^user_pref("extensions.webextensions.uuids", "{\(.*\).*}");/\1/p' "$profile/prefs.js")
+line=$(sed -n -e 's/^user_pref("extensions.webextensions.uuids", "{\(.*\).*}");/\1/p' ../prefs.js)
 
 ## Remove prefix and suffix
 prefix='user_pref("extensions.webextensions.uuids", "{'

--- a/internal_UUID_finder.sh
+++ b/internal_UUID_finder.sh
@@ -31,7 +31,7 @@ IFS=',' read -ra EXTS <<< "$line"
 for i in "${EXTS[@]}"; do
     id=$(echo $i | sed -n 's/.*"\(.*\)\\":.*/\1/p')
     uuid=$(echo $i | sed -n 's/.*"\(.*\)\\".*/\1/p')
-    if test "${styled[$id]+isset}"
+    if [[ -n "${styled[$id]}" ]]
     then
         echo "${styled[$id]}_UUID=$uuid" >> 'ShadowFox_customization/internal_UUIDs.txt'
     fi;


### PR DESCRIPTION
Instead of going through removing the prefixes and suffixes
use a more thorough regex rule to do it all.
