### PR TITLE
override background color of .card-outer

### DIFF
--- a/css/userContent-files/about_pages.css
+++ b/css/userContent-files/about_pages.css
@@ -119,6 +119,7 @@ url-prefix(https://discovery.addons.mozilla.org) {
   #searchWrapper input#searchText,
   .addon .content,
   .addon .logo,
+  .card-outer,
   .card-outer .card-context,
   .card-outer .card-details,
   .search-wrapper input,


### PR DESCRIPTION
fixes the white band on the cards in the about:newtab
![screenshot 2018-05-12 11 11 00](https://user-images.githubusercontent.com/9636256/39954183-7a929418-55ed-11e8-9f0d-2343e6f01e23.png)
