### PR TITLE
Fix white .card-footer

### DIFF
--- a/alternative_user_files/userContent_no_addons.css
+++ b/alternative_user_files/userContent_no_addons.css
@@ -968,6 +968,7 @@ url-prefix(https://discovery.addons.mozilla.org) {
   .Card--photon .Card-contents,
   .Card-contents,
   .Card-contents li,
+  .Card-footer,
   .Card-footer-link,
   .Card-footer-text,
   .Card-header,

--- a/css/userContent-files/amo_store.css
+++ b/css/userContent-files/amo_store.css
@@ -28,6 +28,7 @@
   .Card--photon .Card-contents,
   .Card-contents,
   .Card-contents li,
+  .Card-footer,
   .Card-footer-link,
   .Card-footer-text,
   .Card-header,


### PR DESCRIPTION
![screenshot_2018-06-27 reviews for rlnc proxy client add-ons for firefox](https://user-images.githubusercontent.com/6627739/41969817-945a41b6-7a00-11e8-9199-226a167dc002.png)
