### PR TITLE
Label changes for bottomMacos checkbox

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -276,7 +276,7 @@
                 <li><label><input type="checkbox" id="closeHover">Close Button on Hover</label></li>
                 <li><label><input type="checkbox" id="greyscaleFavicons">Grayscale Favicons</label></li>
                 <li><label><input type="checkbox" id="hideFavicons">Hide Favicons</label></li>
-                <li><label><input type="checkbox" id="bottomMacos">Hide Favicons</label></li>
+                <li><label><input type="checkbox" id="bottomMacos">Bottom Tabs (macOS)</label></li>
                 <li><label><input type="checkbox" id="leftClose">X on left</label></li>
               </ul>
             </div>


### PR DESCRIPTION
Currently it is displaying `Hide Favicons` for this checkbox which I think should be modified to `Bottom Tabs`. Also as it has been tested only in Mac OS (also same is mentioned in the id), Added `macOS` in brackets

You can see that `Hide Favicons` is being displayed 2 times. 

![image](https://user-images.githubusercontent.com/3347300/42276338-5ece5512-7f48-11e8-81d9-818f5e9a7f6c.png)

