### PR TITLE
Fix Violentmonkey white sidebar background

### DIFF
--- a/css/userContent-files/webextension-tweaks/violentmonkey.css
+++ b/css/userContent-files/webextension-tweaks/violentmonkey.css
@@ -11,11 +11,11 @@
     background: var(--in-content-category-header-background)!important;
     border-color: var(--in-content-box-background)!important
   }
-  aside {
-    background: var(--in-content-category-header-background)!important
+  .aside-content {
+    background: var(--in-content-category-header-background)!important;
   }
-  .sidemenu > a.active,
-  .sidemenu > a:hover,
+  .aside-menu > a.active,
+  .aside-menu > a:hover,
   h1,
   h2 {
     color: var(--in-content-link-color)!important


### PR DESCRIPTION
Violentmonkey `v2.9.7` had a white sidebar background.

## Before
![Before](https://i.imgur.com/i2gceqW.png)

## After
![After](https://i.imgur.com/lyUIAJ1.png)