### PR TITLE
Make mention of installation via MacPorts in README and on main site page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ShadowFox styles the entire user interface, protected webpages (such as `about:`
 
 ## Installation and Updating
 
-A cross-platform installer/uninstaller/updater is maintained in the [shadowfox-updater](https://github.com/SrKomodo/shadowfox-updater) repository.  Latest versions can be found in the [releases](https://github.com/SrKomodo/shadowfox-updater/releases) section, or via `Homebrew` and `AUR`.  Please see the [README](https://github.com/SrKomodo/shadowfox-updater/blob/master/README.md) file for details on how to use the updater (GUI and CLI options available) and solutions to common problems.
+A cross-platform installer/uninstaller/updater is maintained in the [shadowfox-updater](https://github.com/SrKomodo/shadowfox-updater) repository.  Latest versions can be found in the [releases](https://github.com/SrKomodo/shadowfox-updater/releases) section, or via `Homebrew`, `MacPorts`, and `AUR`.  Please see the [README](https://github.com/SrKomodo/shadowfox-updater/blob/master/README.md) file for details on how to use the updater (GUI and CLI options available) and solutions to common problems.
 
 ## Customization
 

--- a/website/index.html-e
+++ b/website/index.html-e
@@ -191,7 +191,8 @@
             <ul>
               <li><i class="ion-android-download icon-small"></i><a href="https://github.com/SrKomodo/shadowfox-updater/releases/download/v1.7.11/shadowfox_mac_x32"> MacOS_x32</a></li>
               <li><i class="ion-android-download icon-small"></i><a href="https://github.com/SrKomodo/shadowfox-updater/releases/download/v1.7.11/shadowfox_mac_x64"> MacOS_x64 </a></li>
-              <li><i class="ion-android-done icon-small"></i><a href="https://github.com/overdodactyl/ShadowFox#installation"> Homebrew </a></li>
+              <li><i class="ion-android-done icon-small"></i><a href="https://github.com/overdodactyl/ShadowFox#installation-and-updating"> Homebrew </a></li>
+              <li><i class="ion-android-done icon-small"></i><a href="https://github.com/overdodactyl/ShadowFox#installation-and-updating"> MacPorts </a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
[Since MacPorts accepted this program,](https://github.com/macports/macports-ports/pull/3482) I thought it would be good to update the installation notes. [We discussed this](https://github.com/overdodactyl/ShadowFox/issues/180#issuecomment-409353966) some months ago, but unfortunately I got pretty swamped between then and now[. I'm also updating the instructions in `shadowfox-updater`](https://github.com/SrKomodo/shadowfox-updater/pull/33) and [I updated the notes on the Wiki.](https://github.com/overdodactyl/ShadowFox/wiki/Installation/_compare/ae5ad41a42bc765dbf199c04cea82d0a5e4df9ff...610e742846442601dc91bb6e5ae3f6d2234b9bdc) So hopefully everything should be good after this.