### PR TITLE
Added color variables to file: urls

### DIFF
--- a/css/common-files/color_variables.css
+++ b/css/common-files/color_variables.css
@@ -14,6 +14,7 @@
 @-moz-document url-prefix(https://discovery.addons.mozilla.org),
 url-prefix(chrome://),
 url-prefix(about:),
+url-prefix(file:),
 url(https://www.mozilla.org/credits/),
 url-prefix(https://addons.mozilla.org),
 url-prefix(http://addons.mozilla.org),


### PR DESCRIPTION
The styles for `file:` urls as defined in `css/userContent-files/directory_listings.css` use the colors defined in `css/common-files/color_variables.css` however, the color variables are not applied to `file:` urls.

This commit fixes this oversight and allows `file:` urls to be styled properly.