### PR TITLE
Add support for Momentum

### DIFF
--- a/css/userContent-files/webextension-tweaks/momentum.css
+++ b/css/userContent-files/webextension-tweaks/momentum.css
@@ -1,0 +1,7 @@
+/*! Alters the webextension Momentum
+  IMPORTANT: change the Internal UUID */
+@-moz-document url-prefix("moz-extension://momentum@momentumdash.com/dashboard.html") {
+  body {
+    background-color: var(--tone-8)!important
+  }
+}


### PR DESCRIPTION
Fixes the split second white flash just before the background image is loaded

Momentum addon: https://addons.mozilla.org/en-US/firefox/addon/momentumdash/

Before:
![image](https://user-images.githubusercontent.com/7817101/61685809-f7039080-ad47-11e9-9e23-2b98f941b4d8.png)

After:
![image](https://user-images.githubusercontent.com/7817101/61685961-73966f00-ad48-11e9-8494-648f2e9058aa.png)